### PR TITLE
remove ppx_bisect

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,6 @@
    (>= 4.08))
   ppxlib
   (alcotest :with-test)
-  (ppx_bisect :with-test)
   (ocamlformat
    (and
     :with-test

--- a/ppx_trace.opam
+++ b/ppx_trace.opam
@@ -10,7 +10,6 @@ depends: [
   "ocaml" {>= "4.08"}
   "ppxlib"
   "alcotest" {with-test}
-  "ppx_bisect" {with-test}
   "ocamlformat" {with-test & >= "0.24" & < "0.25"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
`ppx_bisect` doesn't exist 😅

```sh
opam install . --deps-only --with-test
[WARNING] Failed checks on ppx_trace package definition from source at git+file:///Users/corentin/Dev/ppx_trace#main:
    error 23: Missing field 'maintainer'
  warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/: "LICENSE"
[ERROR] Package conflict!
  * Missing dependency:
    - ppx_bisect
    unknown package

No solution found, exiting
```

What you probably meant is [bisect_ppx](https://github.com/aantron/bisect_ppx). I just removed it for now as it seems not to be used