### PR TITLE
pin ppxlib

### DIFF
--- a/ppx_trace.opam
+++ b/ppx_trace.opam
@@ -29,3 +29,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ELLIOTTCABLE/ppx_trace.git"
+pin-depends: [
+  ["ppxlib.dev" "git+https://github.com/ocaml-ppx/ppxlib#95baecb29a89478d3b48b8ea22cdcf032f45be17"]
+]

--- a/ppx_trace.opam.template
+++ b/ppx_trace.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["ppxlib.dev" "git+https://github.com/ocaml-ppx/ppxlib#95baecb29a89478d3b48b8ea22cdcf032f45be17"]
+]


### PR DESCRIPTION
Otherwise `dune build` is failing because latest published version doesn't have `Extension.V3.declare_with_path_arg` yet